### PR TITLE
feat: add support for colons in Handlebars tag names

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 
-import { Handlebars, AsyncHandlebars } from "./index.js"
+import { AsyncHandlebars, Handlebars } from "./index.js"
 
 const hbs = new Handlebars()
 const asyncHbs = new AsyncHandlebars()
@@ -61,6 +61,7 @@ export function Cases () {
 - {{@index}}: {{this}}
 {{/each}}`,
 'Person': `{{name}} is {{age}} years old.`,
+'TagWithColon': `{{some:tag}}`,
 'SimpleIf': `{{#if account}}You have an account!{{else}}You have no account!{{/if}}`,
 'SimpleUnless': `{{#unless account}}You have no account!{{else}}You have an account!{{/unless}}`,
 'NestedIf': `{{~#if account~}}
@@ -176,6 +177,7 @@ ExampleData: {
  * @test #EachWithIndex, { iterator: Map({ John: 12, Susan: 24 }) }
  * @test #Person, { name: 'John', age: 12 }
  * @test #Person, { name: 'Jane', age: 24 }
+ * @test #TagWithColon, { "some:tag": 'John' }
  * @test #SimpleIf, { account: true }
  * @test #SimpleIf, { account: false }
  * @test #SimpleUnless, { account: true }
@@ -237,6 +239,7 @@ export function Run(script, data) {
  * @test #EachWithIndex, { iterator: Map({ John: 12, Susan: 24 }) }
  * @test #Person, { name: 'John', age: 12 }
  * @test #Person, { name: 'Jane', age: 24 }
+ * @test #TagWithColon, { "some:tag": 'John' }
  * @test #SimpleIf, { account: true }
  * @test #SimpleIf, { account: false }
  * @test #NestedIf, { account: true, age: 12 }
@@ -292,6 +295,7 @@ export async function RunAsync(script, data) {
  * @test #EachWithIndex, { iterator: Map({ John: 12, Susan: 24 }) } returns true
  * @test #Person, { name: 'John', age: 12 } returns true
  * @test #Person, { name: 'Jane', age: 24 } returns true
+ * @test #TagWithColon, { "some:tag": 'John' } returns true
  * @test #SimpleIf, { account: true } returns true
  * @test #SimpleIf, { account: false } returns true
  * @test #NestedIf, { account: true, age: 12 } returns true
@@ -333,6 +337,7 @@ export function RunMethodMatch(script, data) {
  * @test #EachWithIndex, { iterator: Map({ John: 12, Susan: 24 }) } resolves true
  * @test #Person, { name: 'John', age: 12 } resolves true
  * @test #Person, { name: 'Jane', age: 24 } resolves true
+ * @test #TagWithColon, { "some:tag": 'John' } resolves true
  * @test #SimpleIf, { account: true } resolves true
  * @test #SimpleIf, { account: false } resolves true
  * @test #NestedIf, { account: true, age: 12 } resolves true

--- a/index.test.js.psnap
+++ b/index.test.js.psnap
@@ -234,5 +234,13 @@
   "RunAsync(#InternalIndexAccess, { iter: [1, 2, 3] })": {
     "value": "0 1\n1 1\n2 1\n0 2\n1 2\n2 2\n0 3\n1 3\n2 3\n",
     "async": true
+  },
+  "Run(#TagWithColon, { \"some:tag\": 'John' })": {
+    "value": "John",
+    "async": false
+  },
+  "RunAsync(#TagWithColon, { \"some:tag\": 'John' })": {
+    "value": "John",
+    "async": true
   }
 }

--- a/parser/grammar.peggy
+++ b/parser/grammar.peggy
@@ -109,9 +109,9 @@ selfTag = "{{" name:TagName args:Arg* "}}" {
 }
 
 eTag = _ "{{/" name:TagName "}}" { return name; }
-TagName = '../'+ [@$a-zA-Z_.0-9-]* { return text(); }
-  / './' [@$a-zA-Z_.0-9-]+ { return text().substring(2); }
-  / ([@$a-zA-Z_.-][@$a-zA-Z_.0-9-]* / "^") { return text(); }
+TagName = '../'+ [@$a-zA-Z_.0-9-\:]* { return text(); }
+  / './' [@$a-zA-Z_.0-9-\:]+ { return text().substring(2); }
+  / ([@$a-zA-Z_.-][@$a-zA-Z_.0-9-\:]* / "^") { return text(); }
 Text = ([^{}\\] / "{" !"{" / "}" !"}")+ { return text(); }
 Arg = _ data:(Func / Boolean / Null / Undefined / HashArg / Variable / Number / Str) _ { return data }
 Variable = ([@$a-zA-Z_./-][@$a-zA-Z_./0-9-]*) { 


### PR DESCRIPTION
This PR modifies the PEG grammar to allow colons in tag names, bringing handlebars-jle's syntax support closer to the main Handlebars project. Added tests to verify proper handling of colon-containing tags.