### PR TITLE
Fix escaped & unescaped behavior for function calls

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -201,9 +201,9 @@ ExampleData: {
  * @test #MatchHash, { x: 'c' } returns '3'
  * @test #EmptyWith, {} returns 'Hi Bob!'
  * @test #Example, #ExampleData
- * @test #SimpleJSON returns '{"name":"John","age":12}'
- * @test #SimpleJSON2 returns '{"name":"John","age":12}'
- * @test #JSONNonDeterministic, { fullName: 'John Doe', actualAge: 20 } returns '{"name":"John Doe","age":20,"test":3}'
+ * @test #SimpleJSON returns '{&quot;name&quot;:&quot;John&quot;,&quot;age&quot;:12}'
+ * @test #SimpleJSON2 returns '{&quot;name&quot;:&quot;John&quot;,&quot;age&quot;:12}'
+ * @test #JSONNonDeterministic, { fullName: 'John Doe', actualAge: 20 } returns '{&quot;name&quot;:&quot;John Doe&quot;,&quot;age&quot;:20,&quot;test&quot;:3}'
  * @test #AddExampleWithTraversal, { addend: 10 }
  * @test #ImplicitIterator, { people: [{ name: 'John', age: 12 }, { name: 'Jane', age: 24 }] }
  * @test #Fallthrough returns 'Woot!'
@@ -218,7 +218,7 @@ ExampleData: {
  * @test #InternalIndexAccess, { iter: [1, 2, 3] }
  * @test #EscapedElement returns 'Hello {{name}}!'
  * @test #EscapedInsideTemplate, { name: 'John' } returns 'Hello \\n John!'
- * @test #EscapedJSON returns '{"name":"<b>John</b>","age":12}'
+ * @test #EscapedJSON returns '{&quot;name&quot;:&quot;&lt;b&gt;John&lt;/b&gt;&quot;,&quot;age&quot;:12}' 
  * @test #UnescapedJSON returns '{"name":"<b>John</b>","age":12}'
  */
 export function Run(script, data) {
@@ -266,9 +266,9 @@ export function Run(script, data) {
  * @test #FetchIterator, { items: [1, 2] }
  * @test #FetchIterator, { items: { a: 1 } }
  * @test #Example, #ExampleData
- * @test #SimpleJSON resolves '{"name":"John","age":12}'
- * @test #SimpleJSON2 resolves '{"name":"John","age":12}'
- * @test #JSONNonDeterministic, { fullName: 'John Doe', actualAge: 20 } resolves '{"name":"John Doe","age":20,"test":3}'
+ * @test #SimpleJSON resolves '{&quot;name&quot;:&quot;John&quot;,&quot;age&quot;:12}'
+ * @test #SimpleJSON2 resolves '{&quot;name&quot;:&quot;John&quot;,&quot;age&quot;:12}'
+ * @test #JSONNonDeterministic, { fullName: 'John Doe', actualAge: 20 } resolves '{&quot;name&quot;:&quot;John Doe&quot;,&quot;age&quot;:20,&quot;test&quot;:3}'
  * @test #AddExampleWithTraversal, { addend: 10 }
  * @test #ImplicitIterator, { people: [{ name: 'John', age: 12 }, { name: 'Jane', age: 24 }] }
  * @test #Unescaped, { name: '<b>John</b>' } resolves '<b>John</b>'
@@ -278,7 +278,7 @@ export function Run(script, data) {
  * @test #NumbersInVariables, { ELEMENT_001: 'John', ELEMENT_003: 'Doe' } resolves 'Hello John let us compute Doe'
  * @test #StaticInternalIndexAccess
  * @test #InternalIndexAccess, { iter: [1, 2, 3] }
- * @test #EscapedJSON resolves '{"name":"<b>John</b>","age":12}'
+ * @test #EscapedJSON resolves '{&quot;name&quot;:&quot;&lt;b&gt;John&lt;/b&gt;&quot;,&quot;age&quot;:12}'
  * @test #UnescapedJSON resolves '{"name":"<b>John</b>","age":12}'
  */
 export async function RunAsync(script, data) {

--- a/index.test.js
+++ b/index.test.js
@@ -153,6 +153,8 @@ ExampleData: {
 {{/each}}`,
 'EscapedElement': 'Hello \\{{name}}!',
 'EscapedInsideTemplate': "Hello \\n {{name}}!",
+'EscapedJSON': `{{json (obj name='<b>John</b>' age=12)}}`,
+'UnescapedJSON': `{{{json (obj name='<b>John</b>' age=12)}}}`,
     }
 }
 
@@ -216,7 +218,8 @@ ExampleData: {
  * @test #InternalIndexAccess, { iter: [1, 2, 3] }
  * @test #EscapedElement returns 'Hello {{name}}!'
  * @test #EscapedInsideTemplate, { name: 'John' } returns 'Hello \\n John!'
- * 
+ * @test #EscapedJSON returns '{"name":"<b>John</b>","age":12}'
+ * @test #UnescapedJSON returns '{"name":"<b>John</b>","age":12}'
  */
 export function Run(script, data) {
     return hbs.compile(script, { recurse: false })(data)
@@ -275,6 +278,8 @@ export function Run(script, data) {
  * @test #NumbersInVariables, { ELEMENT_001: 'John', ELEMENT_003: 'Doe' } resolves 'Hello John let us compute Doe'
  * @test #StaticInternalIndexAccess
  * @test #InternalIndexAccess, { iter: [1, 2, 3] }
+ * @test #EscapedJSON resolves '{"name":"<b>John</b>","age":12}'
+ * @test #UnescapedJSON resolves '{"name":"<b>John</b>","age":12}'
  */
 export async function RunAsync(script, data) {
     return (asyncHbs.compile(script, { recurse: false }))(data)

--- a/methods.js
+++ b/methods.js
@@ -86,6 +86,8 @@ export function setupEngine (engine) {
         engine.fallback.methods = engine.methods
     }
 
+    engine.addMethod('else', () => true, { deterministic: true, sync: true });
+
     // Inspired by escape-html
     // Also, this can be easily overridden for different escaping requirements
     engine.addMethod('escape', (str) => {

--- a/parser/grammar.peggy
+++ b/parser/grammar.peggy
@@ -99,11 +99,12 @@ selfTag = "{{" name:TagName args:Arg* "}}" {
   if (name in (options.methods || {}) && !args.length) return { if: [variableObj, wrapEscape(variableObj), { [name]: [] }] }
   if (!args.length) return wrapEscape(variableObj); 
   return { [name]: args }
-} / "{{{" name:TagName "}}}" {
+} / "{{{" name:TagName args:Arg* "}}}" {
   if (name === '.' || name === "this") return { val: [] }
   if (name === "@index" || name === "@key") return { val: [[1], 'index'] }
   if (name.startsWith("this.")) return { val: name.substring(5).split('.') }
-  return getVar(name.replace(/\.\.\/@?/g, i => i.includes('@') ? i : '../../').replace(/\.\.\/this\.?/g, '../'))
+  if (!args.length) return getVar(name.replace(/\.\.\/@?/g, i => i.includes('@') ? i : '../../').replace(/\.\.\/this\.?/g, '../'))
+  return { [name]: args }
 } /  "{{>" _ name:TagName args:Arg* "}}" {
   return { "%partial": [name, ...args] }
 }

--- a/parser/grammar.peggy
+++ b/parser/grammar.peggy
@@ -93,12 +93,12 @@ asBlock = "|" _ names:Arg* _ "|" { return names }
 selfTag = "{{" name:TagName args:Arg* "}}" { 
   if (name === '.' || name === 'this') return wrapEscape({ val: [] })
   if (name === "@key" || name === "@index") return wrapEscape({ val: [[1], 'index'] })
-  if (name === '^') return wrapEscape(getVar('else'))
+  if (name === '^') return { else: true }
   if (name.startsWith("this.")) return wrapEscape({ val: name.substring(5).split('.') })
   const variableObj = getVar(name.replace(/\.\.\/@?/g, i => i.includes('@') ? '../' : '../../').replace(/\.\.\/this\.?/g, '../'))
   if (name in (options.methods || {}) && !args.length) return { if: [variableObj, wrapEscape(variableObj), { [name]: [] }] }
   if (!args.length) return wrapEscape(variableObj); 
-  return { [name]: args }
+  return wrapEscape({ [name]: args })
 } / "{{{" name:TagName args:Arg* "}}}" {
   if (name === '.' || name === "this") return { val: [] }
   if (name === "@index" || name === "@key") return { val: [[1], 'index'] }


### PR DESCRIPTION
**Before**:
- `{{{json var}}}` would break the parser because it could not handle function-calling within triple curly braces. 
- `{{json var}}` would produce an unescaped output, which is **incorrect** behavior according to the Handlebars syntax.

**This PR**: 

- [x] Fixes function calls within double curly braces to produce **escaped** outputs (expected Handlebars behavior) and fixes corresponding tests
- [x] Adds support for **unescaped** function outputs in triple curlies

**Expected handlebars behavior**:
<img width="1546" alt="Screenshot 2025-04-15 at 1 14 36 PM" src="https://github.com/user-attachments/assets/4f685287-298c-48e6-9b41-3dd56a223896" />

Closes https://github.com/TotalTechGeek/handlebars-jle/issues/9.