### PR TITLE
feat: allow tags to start with numeric characters

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -62,6 +62,7 @@ export function Cases () {
 {{/each}}`,
 'Person': `{{name}} is {{age}} years old.`,
 'TagWithColon': `{{some:tag}}`,
+'TagWithNumber': `{{2024_tag}}`,
 'SimpleIf': `{{#if account}}You have an account!{{else}}You have no account!{{/if}}`,
 'SimpleUnless': `{{#unless account}}You have no account!{{else}}You have an account!{{/unless}}`,
 'NestedIf': `{{~#if account~}}
@@ -180,6 +181,7 @@ ExampleData: {
  * @test #Person, { name: 'John', age: 12 }
  * @test #Person, { name: 'Jane', age: 24 }
  * @test #TagWithColon, { "some:tag": 'John' }
+ * @test #TagWithNumber, { "2024_tag": '2024' }
  * @test #SimpleIf, { account: true }
  * @test #SimpleIf, { account: false }
  * @test #SimpleIf, { account: {} }
@@ -246,6 +248,7 @@ export function Run(script, data) {
  * @test #Person, { name: 'John', age: 12 }
  * @test #Person, { name: 'Jane', age: 24 }
  * @test #TagWithColon, { "some:tag": 'John' }
+ * @test #TagWithNumber, { "2024_tag": '2024' }
  * @test #SimpleIf, { account: true }
  * @test #SimpleIf, { account: false }
  * @test #SimpleIf, { account: {} }
@@ -307,6 +310,7 @@ export async function RunAsync(script, data) {
  * @test #Person, { name: 'John', age: 12 } returns true
  * @test #Person, { name: 'Jane', age: 24 } returns true
  * @test #TagWithColon, { "some:tag": 'John' } returns true
+ * @test #TagWithNumber, { "2024_tag": '2024' } returns true
  * @test #SimpleIf, { account: true } returns true
  * @test #SimpleIf, { account: false } returns true
  * @test #SimpleIf, { account: {} } returns true
@@ -352,6 +356,7 @@ export function RunMethodMatch(script, data) {
  * @test #Person, { name: 'John', age: 12 } resolves true
  * @test #Person, { name: 'Jane', age: 24 } resolves true
  * @test #TagWithColon, { "some:tag": 'John' } resolves true
+ * @test #TagWithNumber, { "2024_tag": '2024' } resolves true
  * @test #SimpleIf, { account: true } resolves true
  * @test #SimpleIf, { account: false } resolves true
  * @test #SimpleIf, { account: {} } resolves true

--- a/index.test.js.psnap
+++ b/index.test.js.psnap
@@ -266,5 +266,13 @@
   "RunAsync(#SimpleIf, { account: Set([]) })": {
     "value": "You have no account!",
     "async": true
+  },
+  "Run(#TagWithNumber, { \"2024_tag\": '2024' })": {
+    "value": "2024",
+    "async": false
+  },
+  "RunAsync(#TagWithNumber, { \"2024_tag\": '2024' })": {
+    "value": "2024",
+    "async": true
   }
 }

--- a/parser/grammar.peggy
+++ b/parser/grammar.peggy
@@ -113,7 +113,7 @@ selfTag = "{{" name:TagName args:Arg* "}}" {
 eTag = _ "{{/" name:TagName "}}" { return name; }
 TagName = '../'+ [@$a-zA-Z_.0-9-\:]* { return text(); }
   / './' [@$a-zA-Z_.0-9-\:]+ { return text().substring(2); }
-  / ([@$a-zA-Z_.-][@$a-zA-Z_.0-9-\:]* / "^") { return text(); }
+  / ([@$a-zA-Z_.0-9-][@$a-zA-Z_.0-9-\:]* / "^") { return text(); }
 Text = ([^{}\\] / "{" !"{" / "}" !"}")+ { return text(); }
 Arg = _ data:(Func / Boolean / Null / Undefined / HashArg / Variable / Number / Str) _ { return data }
 Variable = ([@$a-zA-Z_./-][@$a-zA-Z_./0-9-]*) { 


### PR DESCRIPTION
- Modified the `TagName` grammar rule in `grammar.peggy` to accept leading digits.
- Added a new test case `TagWithNumber` in `index.test.js` using a tag named `{{2024_tag}}`.
- Updated test snapshots in `index.test.js.psnap` to reflect expected outputs for the new tag format.